### PR TITLE
Add foreign language audio support

### DIFF
--- a/Legion/ExportManager.cpp
+++ b/Legion/ExportManager.cpp
@@ -116,8 +116,9 @@ void ExportManager::ExportMilesAssets(const std::unique_ptr<MilesLib>& MilesFile
 			auto& Asset = ExportAssets[AssetToConvert];
 			auto& AudioAsset = MilesFileSystem->Assets[Asset.AssetHash];
 			auto  Path = IO::Path::Combine(ExportDirectory, "sounds");
-			if (AudioAsset.LocalizeIndex != -1) {
-				auto Name = LanguageName((MilesLanguageID)AudioAsset.LocalizeIndex);
+			auto  UseSubfolders = ExportManager::Config.Get<System::SettingType::Boolean>("AudioLanguageFolders");
+			if (UseSubfolders && AudioAsset.LocalizeIndex != -1) {
+				auto &Name = LanguageName((MilesLanguageID)AudioAsset.LocalizeIndex);
 				IO::Directory::CreateDirectory(IO::Path::Combine(Path, Name));
 				Path = IO::Path::Combine(Path, Name);
 			}

--- a/Legion/ExportManager.cpp
+++ b/Legion/ExportManager.cpp
@@ -115,8 +115,15 @@ void ExportManager::ExportMilesAssets(const std::unique_ptr<MilesLib>& MilesFile
 
 			auto& Asset = ExportAssets[AssetToConvert];
 			auto& AudioAsset = MilesFileSystem->Assets[Asset.AssetHash];
+			auto  Path = IO::Path::Combine(ExportDirectory, "sounds");
+			if (AudioAsset.LocalizeIndex != -1) {
+				auto Name = LanguageName((MilesLanguageID)AudioAsset.LocalizeIndex);
+				IO::Directory::CreateDirectory(IO::Path::Combine(Path, Name));
+				Path = IO::Path::Combine(Path, Name);
+			}
+			Path = IO::Path::Combine(Path, AudioAsset.Name + ".wav");
 
-			bool bSuccess = MilesFileSystem->ExtractAsset(AudioAsset, IO::Path::Combine(IO::Path::Combine(ExportDirectory, "sounds"), AudioAsset.Name + ".wav"));
+			bool bSuccess = MilesFileSystem->ExtractAsset(AudioAsset, Path);
 
 			if (!bSuccess)
 			{
@@ -128,7 +135,7 @@ void ExportManager::ExportMilesAssets(const std::unique_ptr<MilesLib>& MilesFile
 
 			{
 				std::lock_guard<std::mutex> UpdateLock(UpdateMutex);
-				auto NewProgress = (uint32_t)(((float)AssetToConvert / (float)ExportAssets.Count()) * 100.f);
+				auto NewProgress = (uint32_t)(((float)(AssetToConvert + 1) / (float)ExportAssets.Count()) * 100.f);
 
 				if (NewProgress > CurrentProgress)
 				{
@@ -137,9 +144,9 @@ void ExportManager::ExportMilesAssets(const std::unique_ptr<MilesLib>& MilesFile
 				}
 			}
 		}
+		ProgressCallback(100, MainForm, true);
 	});
 
-	ProgressCallback(100, MainForm, true);
 }
 
 void ExportManager::ExportRpakAssets(const std::unique_ptr<RpakLib>& RpakFileSystem, List<ExportAsset> ExportAssets, ExportProgressCallback ProgressCallback, CheckStatusCallback StatusCallback, Forms::Form* MainForm)

--- a/Legion/LegionMain.cpp
+++ b/Legion/LegionMain.cpp
@@ -223,12 +223,9 @@ void LegionMain::LoadApexFile(const List<string>& File)
 
 				ThisPtr->RefreshView();
 			}
-			catch (...)
+			catch (const std::exception& e)
 			{
-				ThisPtr->Invoke([]()
-				{
-					Forms::MessageBox::Show("An error occured while loading the MBNK.", "Legion+", Forms::MessageBoxButtons::OK, Forms::MessageBoxIcon::Warning);
-				});
+				Forms::MessageBox::Show("An error occurred while loading the MBNK:\n" + string(e.what()), "Legion+", Forms::MessageBoxButtons::OK, Forms::MessageBoxIcon::Warning);
 				ThisPtr->StatusLabel->SetText("Idle");
 			}
 		}

--- a/Legion/LegionSettings.cpp
+++ b/Legion/LegionSettings.cpp
@@ -190,6 +190,14 @@ void LegionSettings::InitializeComponent()
 	this->ToggleOverwriting->SetAnchor(Forms::AnchorStyles::Top | Forms::AnchorStyles::Left);
 	this->groupBox4->AddControl(this->ToggleOverwriting);
 
+	this->ToggleAudioLanguageFolders = new UIX::UIXCheckBox();
+	this->ToggleAudioLanguageFolders->SetSize({ 150, 18 });
+	this->ToggleAudioLanguageFolders->SetLocation({ 130, 20 });
+	this->ToggleAudioLanguageFolders->SetTabIndex(2);
+	this->ToggleAudioLanguageFolders->SetText("Audio Language Folders");
+	this->ToggleAudioLanguageFolders->SetAnchor(Forms::AnchorStyles::Top | Forms::AnchorStyles::Left);
+	this->groupBox4->AddControl(this->ToggleAudioLanguageFolders);
+
 	//
 	//	Assets Export Settings Box
 	//
@@ -458,6 +466,7 @@ void LegionSettings::LoadSettings()
 	this->LoadDataTables->SetChecked(ExportManager::Config.Get<System::SettingType::Boolean>("LoadDataTables"));
 	this->LoadShaderSets->SetChecked(ExportManager::Config.Get<System::SettingType::Boolean>("LoadShaderSets"));
 	this->ToggleOverwriting->SetChecked(ExportManager::Config.Get<System::SettingType::Boolean>("OverwriteExistingFiles"));
+	this->ToggleAudioLanguageFolders->SetChecked(ExportManager::Config.Get<System::SettingType::Boolean>("AudioLanguageFolders"));
 
 
 	if (ExportManager::Config.Has<System::SettingType::String>("ExportDirectory"))
@@ -596,6 +605,7 @@ void LegionSettings::OnClose(const std::unique_ptr<FormClosingEventArgs>& EventA
 	ExportManager::Config.Set<System::SettingType::Boolean>("LoadDataTables", ThisPtr->LoadDataTables->Checked());
 	ExportManager::Config.Set<System::SettingType::Boolean>("LoadShaderSets", ThisPtr->LoadShaderSets->Checked());
 	ExportManager::Config.Set<System::SettingType::Boolean>("OverwriteExistingFiles", ThisPtr->ToggleOverwriting->Checked());
+	ExportManager::Config.Set<System::SettingType::Boolean>("AudioLanguageFolders", ThisPtr->ToggleAudioLanguageFolders->Checked());
 	ExportManager::Config.Set<System::SettingType::Integer>("ModelFormat", (uint32_t)ModelExportFormat);
 	ExportManager::Config.Set<System::SettingType::Integer>("AnimFormat", (uint32_t)AnimExportFormat);
 	ExportManager::Config.Set<System::SettingType::Integer>("ImageFormat", (uint32_t)ImageExportFormat);

--- a/Legion/LegionSettings.cpp
+++ b/Legion/LegionSettings.cpp
@@ -3,6 +3,7 @@
 #include "ExportManager.h"
 #include "Process.h"
 #include "LegionMain.h"
+#include "MilesLib.h"
 
 LegionSettings::LegionSettings()
 	: Forms::Form()
@@ -307,6 +308,15 @@ void LegionSettings::InitializeComponent()
 	this->label6->SetTextAlign(Drawing::ContentAlignment::TopLeft);
 	this->groupBox5->AddControl(this->label6);
 
+	this->label7 = new UIX::UIXLabel();
+	this->label7->SetSize({ 120, 15 });
+	this->label7->SetLocation({ 125, 110 });
+	this->label7->SetTabIndex(9);
+	this->label7->SetText("Audio Language");
+	this->label7->SetAnchor(Forms::AnchorStyles::Top | Forms::AnchorStyles::Left);
+	this->label7->SetTextAlign(Drawing::ContentAlignment::TopLeft);
+	this->groupBox5->AddControl(this->label7);
+
 	this->NormalRecalcType = new UIX::UIXComboBox();
 	this->NormalRecalcType->SetSize({ 90, 20 });
 	this->NormalRecalcType->SetLocation({ 125, 80 });
@@ -317,6 +327,17 @@ void LegionSettings::InitializeComponent()
 	this->NormalRecalcType->Items.Add("DirectX");
 	this->NormalRecalcType->Items.Add("OpenGL");
 	this->groupBox5->AddControl(this->NormalRecalcType);
+
+	this->AudioLanguage = new UIX::UIXComboBox();
+	this->AudioLanguage->SetSize({ 90, 20 });
+	this->AudioLanguage->SetLocation({ 125, 125 });
+	this->AudioLanguage->SetTabIndex(0);
+	this->AudioLanguage->SetAnchor(Forms::AnchorStyles::Top | Forms::AnchorStyles::Left);
+	this->AudioLanguage->SetDropDownStyle(Forms::ComboBoxStyle::DropDownList);
+	for (int i = (int)MilesLanguageID::English; i <= (int)MilesLanguageID::Korean; i++) {
+		this->AudioLanguage->Items.Add(imstring(LanguageName((MilesLanguageID)i)));
+	}
+	this->groupBox5->AddControl(this->AudioLanguage);
 
 	this->ResumeLayout(false);
 	this->PerformLayout();
@@ -339,6 +360,7 @@ void LegionSettings::LoadSettings()
 	auto ImageFormat = (RpakImageExportFormat)ExportManager::Config.Get<System::SettingType::Integer>("ImageFormat");
 	auto SubtitlesFormat = (RpakSubtitlesExportFormat)ExportManager::Config.Get<System::SettingType::Integer>("SubtitlesFormat");
 	auto NormalRecalcType = (eNormalRecalcType)ExportManager::Config.Get<System::SettingType::Integer>("NormalRecalcType");
+	auto AudioLanguage = (MilesLanguageID)ExportManager::Config.Get<System::SettingType::Integer>("AudioLanguage");
 
 	if (!ExportManager::Config.Has("NormalRecalcType"))
 		NormalRecalcType = eNormalRecalcType::OpenGl;
@@ -426,6 +448,8 @@ void LegionSettings::LoadSettings()
 		break;
 	}
 
+	this->AudioLanguage->SetSelectedIndex(static_cast<int32_t>(AudioLanguage));
+
 	this->LoadModels->SetChecked(ExportManager::Config.Get<System::SettingType::Boolean>("LoadModels"));
 	this->LoadAnimations->SetChecked(ExportManager::Config.Get<System::SettingType::Boolean>("LoadAnimations"));
 	this->LoadImages->SetChecked(ExportManager::Config.Get<System::SettingType::Boolean>("LoadImages"));
@@ -457,6 +481,7 @@ void LegionSettings::OnClose(const std::unique_ptr<FormClosingEventArgs>& EventA
 	auto ImageExportFormat = RpakImageExportFormat::Dds;
 	auto SubtitlesExportFormat = RpakSubtitlesExportFormat::CSV;
 	auto NormalRecalcType = eNormalRecalcType::OpenGl;
+	auto AudioLanguage = MilesLanguageID::English;
 
 	if (ThisPtr->ModelExportFormat->SelectedIndex() > -1)
 	{
@@ -541,6 +566,10 @@ void LegionSettings::OnClose(const std::unique_ptr<FormClosingEventArgs>& EventA
 		}
 	}
 
+	if (ThisPtr->AudioLanguage->SelectedIndex() > -1) {
+		AudioLanguage = (MilesLanguageID)ThisPtr->AudioLanguage->SelectedIndex();
+	}
+
 	// have the settings actually changed?
 	bool bRefreshView = false;
 
@@ -572,6 +601,7 @@ void LegionSettings::OnClose(const std::unique_ptr<FormClosingEventArgs>& EventA
 	ExportManager::Config.Set<System::SettingType::Integer>("ImageFormat", (uint32_t)ImageExportFormat);
 	ExportManager::Config.Set<System::SettingType::Integer>("SubtitlesFormat", (uint32_t)SubtitlesExportFormat);
 	ExportManager::Config.Set<System::SettingType::Integer>("NormalRecalcType", (uint32_t)NormalRecalcType);
+	ExportManager::Config.Set<System::SettingType::Integer>("AudioLanguage", (uint32_t)AudioLanguage);
 
 	auto ExportDirectory = ThisPtr->ExportBrowseFolder->Text();
 

--- a/Legion/LegionSettings.h
+++ b/Legion/LegionSettings.h
@@ -55,6 +55,7 @@ private:
 	UIX::UIXCheckBox* LoadModels;
 	// Toggles
 	UIX::UIXCheckBox* ToggleOverwriting;
+	UIX::UIXCheckBox* ToggleAudioLanguageFolders;
 	// Export Types
 	UIX::UIXComboBox* ModelExportFormat;
 	UIX::UIXComboBox* AnimExportFormat;

--- a/Legion/LegionSettings.h
+++ b/Legion/LegionSettings.h
@@ -38,6 +38,7 @@ private:
 	UIX::UIXLabel* label4;
 	UIX::UIXLabel* label5;
 	UIX::UIXLabel* label6;
+	UIX::UIXLabel* label7;
 	// Boxes
 	UIX::UIXGroupBox* groupBox1;
 	UIX::UIXGroupBox* groupBox2;
@@ -60,6 +61,7 @@ private:
 	UIX::UIXComboBox* ImageExportFormat;
 	UIX::UIXComboBox* SubtitlesExportFormat;
 	UIX::UIXComboBox* NormalRecalcType;
+	UIX::UIXComboBox* AudioLanguage;
 	// Export Formats
 	UIX::UIXRadioButton* ExportCastAnim;
 	UIX::UIXRadioButton* ExportSEAnim;

--- a/Legion/MilesLib.h
+++ b/Legion/MilesLib.h
@@ -46,7 +46,7 @@ struct MilesAudioAsset
 	uint32_t StreamSize;
 
 	uint32_t PatchIndex;
-	uint32_t LocalizeIndex;
+	int32_t LocalizeIndex;
 
 	MilesAudioAsset() = default;
 };
@@ -58,6 +58,26 @@ struct MilesStreamBank
 
 	MilesStreamBank() = default;
 };
+
+enum class MilesLanguageID : int16_t
+{
+	None = -1,
+	English = 0,
+	French = 1,
+	German = 2,
+	Spanish = 3,
+	Italian = 4,
+	Japanese = 5,
+	Polish = 6,
+	Russian = 7,
+	Mandarin = 8,
+	Korean = 9,
+	UNKNOWN = 10,
+	COUNT = 11,
+};
+
+const String&
+LanguageName(MilesLanguageID lang);
 
 class MilesLib
 {

--- a/Legion/RpakAssetExtract.cpp
+++ b/Legion/RpakAssetExtract.cpp
@@ -642,6 +642,7 @@ RMdlMaterial RpakLib::ExtractMaterial(const RpakLoadAsset& Asset, const string& 
 		}
 		else {
 			g_Logger.Warning("Shaderset for material '%s' referenced a pixel shader that is not currently loaded. Unable to associate texture types.\n", Result.MaterialName);
+			g_Logger.Warning("Shaderset for material '%s' referenced a pixel shader that is not currently loaded. Unable to associate texture types.\n", Result.MaterialName.ToCString());
 		}
 	}
 


### PR DESCRIPTION
Users may now export audio in any language supported by the game. A new "Audio Language" setting is available under the Asset Export Settings to choose a desired language. As before, audio can be extracted from the game by loading the file `audio/ship/general.mbnk` from the game's installation directory.

- Extracted voice lines are saved to the `exported_files/sounds/[language]/` directory. Audio without dialogue is saved directly to `exported_files/sounds` regardless of selected language.
- Each language's audio requires the files `general_[language].mstr` and `general_[language]_patch_1.mstr`.
  - By default these are downloaded to the `audio/ship/` directory in the Apex installation folder when the game language is changed in Steam or Origin.
  - Legion+ will search for these files in the same directory as the imported `general.mbnk` file, but will prompt the user to browse for them if not found.
  - NOTE: Steam/Origin will delete the previously installed `.mstr` files if you switch between two non-English languages (English language files are never deleted). If you want to extract audio in multiple languages, consider backing up the two above mentioned `.mstr` files before switching the game's language.
- The selected language is applied as soon as `general.mbnk` file is imported into Legion+. This file must be re-imported every time the audio language selection is changed.