### PR TITLE
Hardcoding Up filter for PNG

### DIFF
--- a/cppnet/cppkore/Texture.cpp
+++ b/cppnet/cppkore/Texture.cpp
@@ -265,6 +265,16 @@ namespace Assets
 				break;
 			case SaveFileType::Png:
 				Wc = DirectX::GetWICCodec(DirectX::WICCodecs::WIC_CODEC_PNG);
+				PropertyWriter = [](IPropertyBag2* props)
+				{
+					PROPBAG2 options{};
+					VARIANT varValues{};
+					options.pstrName = (LPOLESTR)L"FilterOption";
+					varValues.vt = VT_UI1;
+					varValues.bVal = WICPngFilterOption::WICPngFilterUp;
+
+					(void)props->Write(1, &options, &varValues);
+				};
 				break;
 			case SaveFileType::Tiff:
 				Wc = DirectX::GetWICCodec(DirectX::WICCodecs::WIC_CODEC_TIFF);


### PR DESCRIPTION
Did not see significant performance difference between None or Up filtering so went with the latter.
Somewhat reduces the time needed to export (~4/5th on avg. compared to current) and file size for majority of the textures for PNG format.