### PR TITLE
Changed the size of the Nightly build text so it's not cut off

### DIFF
--- a/Legion/src/LegionSettings.cpp
+++ b/Legion/src/LegionSettings.cpp
@@ -119,7 +119,7 @@ void LegionSettings::InitializeComponent()
 	//	About Text Label
 	//
 	this->labelVersion = new UIX::UIXLabel();
-	this->labelVersion->SetSize({ 200, 12 });
+	this->labelVersion->SetSize({ 200, 20 });
 	this->labelVersion->SetLocation({ 12, 20 });
 	this->labelVersion->SetTabIndex(0);
 #ifndef NIGHTLY


### PR DESCRIPTION
The Nightly build text is cut off at the bottom, so i made the text box bigger so it doesn't cut off
![image](https://user-images.githubusercontent.com/53872542/194064512-f30b989c-4c2d-49a8-a953-10b506ca0e82.png)


