### PR TITLE
Added a --loadall flag that loads all the flags

### DIFF
--- a/Legion/src/Main.cpp
+++ b/Legion/src/Main.cpp
@@ -289,6 +289,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 			}
 			else if (bLoadAll)
 			{
+				std::array<bool, 11> bAssets = {
 				true, // LoadModels
 				true, // LoadAnims
 				true, // LoadAnimSeqs
@@ -299,7 +300,8 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 				true, // LoadShaderSets
 				true, // LoadSettingsSets
 				true, // LoadRSONs
-				false // LoadEffects, not ready yet.
+				false // LoadEffects not ready yet.
+				};
 			}
 			else
 			{

--- a/Legion/src/Main.cpp
+++ b/Legion/src/Main.cpp
@@ -302,6 +302,8 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 				true, // LoadRSONs
 				false // LoadEffects not ready yet.
 				};
+
+				AssetList = Rpak->BuildAssetList(bAssets);
 			}
 			else
 			{

--- a/Legion/src/Main.cpp
+++ b/Legion/src/Main.cpp
@@ -255,6 +255,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 			std::unique_ptr<List<ApexAsset>> AssetList;
 
 			// load rpak flags
+			bool bLoadAll = cmdline.HasParam(L"--loadall");
 			bool bLoadModels = cmdline.HasParam(L"--loadmodels");
 			bool bLoadAnims = cmdline.HasParam(L"--loadanimations");
 			bool BLoadAnimSeqs = cmdline.HasParam(L"--loadanimationseqs");
@@ -266,7 +267,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 			bool bLoadSettingsSets = cmdline.HasParam(L"--loadsettingssets");
 			bool bLoadRSONs = cmdline.HasParam(L"--loadrsons");
 
-			bool bNoFlagsSpecified = !bLoadModels && !bLoadAnims && !BLoadAnimSeqs && !bLoadImages && !bLoadMaterials && !bLoadUIImages && !bLoadDataTables && !bLoadShaderSets && !bLoadSettingsSets && !bLoadRSONs;
+			bool bNoFlagsSpecified = !bLoadAll && !bLoadModels && !bLoadAnims && !BLoadAnimSeqs && !bLoadImages && !bLoadMaterials && !bLoadUIImages && !bLoadDataTables && !bLoadShaderSets && !bLoadSettingsSets && !bLoadRSONs;
 
 			if (bNoFlagsSpecified)
 			{
@@ -286,6 +287,20 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 
 				AssetList = Rpak->BuildAssetList(bAssets);
 			}
+			else if (bLoadAll)
+			{
+				true, // LoadModels
+				true, // LoadAnims
+				true, // LoadAnimSeqs
+				true, // LoadImages
+				true, // LoadMaterials
+				true, // LoadUIImages
+				true, // LoadDataTables
+				true, // LoadShaderSets
+				true, // LoadSettingsSets
+				true, // LoadRSONs
+				false // LoadEffects, not ready yet.
+			}
 			else
 			{
 				std::array<bool, 11> bAssets = {
@@ -299,7 +314,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 					bLoadShaderSets,
 					bLoadSettingsSets,
 					bLoadRSONs,
-					false // not ready yet.
+					false // LoadEffects, not ready yet.
 				};
 
 				AssetList = Rpak->BuildAssetList(bAssets);

--- a/Legion/src/Main.cpp
+++ b/Legion/src/Main.cpp
@@ -290,17 +290,17 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 			else if (bLoadAll)
 			{
 				std::array<bool, 11> bAssets = {
-				true, // LoadModels
-				true, // LoadAnims
-				true, // LoadAnimSeqs
-				true, // LoadImages
-				true, // LoadMaterials
-				true, // LoadUIImages
-				true, // LoadDataTables
-				true, // LoadShaderSets
-				true, // LoadSettingsSets
-				true, // LoadRSONs
-				false // LoadEffects not ready yet.
+					true, // LoadModels
+					true, // LoadAnims
+					true, // LoadAnimSeqs
+					true, // LoadImages
+					true, // LoadMaterials
+					true, // LoadUIImages
+					true, // LoadDataTables
+					true, // LoadShaderSets
+					true, // LoadSettingsSets
+					true, // LoadRSONs
+					false // LoadEffects not ready yet.
 				};
 
 				AssetList = Rpak->BuildAssetList(bAssets);

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ When any load flag is used, your saved configuration is ignored and only the spe
 When multiple load flags are used together, all specified types will be loaded
 
 ```
+--loadall - This flag loads all the flags below
 --loadmodels
 --loadanimations
 --loadimages


### PR DESCRIPTION
We are getting kinda lot of flags now so i think it would be nice with one flag that loads them all, so we don't need to have a long ass command line 
![image](https://user-images.githubusercontent.com/53872542/195723700-4c630077-7b01-4b21-add2-a327c5612d09.png)
vs
![image](https://user-images.githubusercontent.com/53872542/195731194-49b7f242-6ad7-4c51-bbf2-e48e4127b864.png)
