### PR TITLE
Made BSP / Map Exporting automatically use Cast models and Pngs

### DIFF
--- a/Legion/src/LegionMain.cpp
+++ b/Legion/src/LegionMain.cpp
@@ -187,21 +187,28 @@ void LegionMain::LoadApexFile(const List<string>& File)
 			auto BspLib = std::make_unique<RBspLib>();
 			try
 			{
+				// force short paths, Cast and Pngs when exporting bsp
+				bool useFullPaths = ExportManager::Config.GetBool("UseFullPaths");
+				bool modelFormat = ExportManager::Config.GetBool("ModelFormat");
+				bool imageFormat = ExportManager::Config.GetBool("ImageFormat");
+
+				ExportManager::Config.SetBool("UseFullPaths", false);
+				ExportManager::Config.SetInt("ModelFormat", (uint32_t)ModelExportFormat_t::Cast);
+				ExportManager::Config.SetInt("ImageFormat", (uint32_t)ImageExportFormat_t::Png);
+
 				if (Main->RpakFileSystem != nullptr)
 				{
 					Main->RpakFileSystem->InitializeImageExporter((ImageExportFormat_t)ExportManager::Config.Get<System::SettingType::Integer>("ImageFormat"));
 					Main->RpakFileSystem->InitializeModelExporter((ModelExportFormat_t)ExportManager::Config.Get<System::SettingType::Integer>("ModelFormat"));
 				}
-				
-				// force short paths when exporting bsp
-				bool useFullPaths = ExportManager::Config.GetBool("UseFullPaths");
-				ExportManager::Config.SetBool("UseFullPaths", false);
 
 				BspLib->InitializeModelExporter((ModelExportFormat_t)ExportManager::Config.Get<System::SettingType::Integer>("ModelFormat"));
 				BspLib->ExportBsp(Main->RpakFileSystem, Main->LoadPath[0], ExportManager::GetMapExportPath());
 
 				// restore original setting
 				ExportManager::Config.SetBool("UseFullPaths", useFullPaths);
+				ExportManager::Config.SetInt("ModelFormat", (uint32_t)modelFormat);
+				ExportManager::Config.SetInt("ImageFormat", (uint32_t)imageFormat);
 
 				Main->Invoke([]()
 				{


### PR DESCRIPTION
The BSP blender plugin only works with cast and blender doesn't work with dds (the default image in settings), so i just made the exporting use those two assets automatically, so people don't need to be careful about it and we don't need to give them support when they don't do it (the reason why i wanted to add this https://discord.com/channels/919342067463888896/1001087938735656960/1039660090120216647)