### PR TITLE
removed an \n

### DIFF
--- a/Legion/src/Assets/material.cpp
+++ b/Legion/src/Assets/material.cpp
@@ -312,7 +312,7 @@ RMdlMaterial RpakLib::ExtractMaterial(const RpakLoadAsset& Asset, const string& 
 		}
 	}
 
-	g_Logger.Info("\nMaterial Info for '%s' (%llX)\n", Result.MaterialName.ToCString(), Asset.NameHash);
+	g_Logger.Info("Material Info for '%s' (%llX)\n", Result.MaterialName.ToCString(), Asset.NameHash);
 
 	if (Asset.Version == RpakGameVersion::Apex)
 	{


### PR DESCRIPTION
removed an \n and made the format of the text for the logger look weird and unlike the looks of the others formats

How it looks like rn
![image](https://user-images.githubusercontent.com/53872542/224435735-f433930e-6132-49d1-8c3c-3b2d36f5d762.png)

and how it should look like
![image](https://user-images.githubusercontent.com/53872542/224436510-d6e8fcf9-b8e2-44d4-ba4b-23868c3046de.png)
