### PR TITLE
advanced removal of a \n, superseding #113

### DIFF
--- a/Legion/src/Assets/material.cpp
+++ b/Legion/src/Assets/material.cpp
@@ -312,7 +312,7 @@ RMdlMaterial RpakLib::ExtractMaterial(const RpakLoadAsset& Asset, const string& 
 		}
 	}
 
-	g_Logger.Info("\nMaterial Info for '%s' (%llX)\n", Result.MaterialName.ToCString(), Asset.NameHash);
+	g_Logger.Info("Material Info for '%s' (%llX)\n", Result.MaterialName.ToCString(), Asset.NameHash);
 
 	if (Asset.Version == RpakGameVersion::Apex)
 	{


### PR DESCRIPTION
removed an \n and made the format of the text for the logger look weird and unlike the looks of the others formats