### PR TITLE
Add extraction of compressed wrap files

### DIFF
--- a/Legion/src/Assets/wrap.cpp
+++ b/Legion/src/Assets/wrap.cpp
@@ -60,6 +60,8 @@ void RpakLib::ExportWrappedFile(const RpakLoadAsset& Asset, const string& Path)
 			stream->Read((uint8_t*)decompressedBuffer, 0, Header.dcmpSize);
 			stream->Close();
 			ofs.write(decompressedBuffer, Header.dcmpSize - 1);
+
+			delete[] decompressedBuffer;
 		}
 		else
 		{

--- a/Legion/src/Assets/wrap.cpp
+++ b/Legion/src/Assets/wrap.cpp
@@ -2,6 +2,7 @@
 #include "RpakLib.h"
 #include "Path.h"
 #include "Directory.h"
+#include <rtech.h>
 
 void RpakLib::BuildWrapInfo(const RpakLoadAsset& Asset, ApexAsset& Info)
 {
@@ -49,7 +50,16 @@ void RpakLib::ExportWrappedFile(const RpakLoadAsset& Asset, const string& Path)
 		std::unique_ptr<IO::MemoryStream> stream;
 		if (Header.flags & 1) // compressed
 		{
+			auto compressedBuffer = new uint8_t[Header.cmpSize];
+			Reader.Read(compressedBuffer, 0, Header.cmpSize);
+			uint64_t bufferSize = Header.dcmpSize;
 
+			std::unique_ptr<IO::MemoryStream> stream = RTech::DecompressStreamedBuffer(compressedBuffer, bufferSize, (uint8_t)CompressionType::OODLE);
+			
+			char* decompressedBuffer = new char[Header.dcmpSize];
+			stream->Read((uint8_t*)decompressedBuffer, 0, Header.dcmpSize);
+			stream->Close();
+			ofs.write(decompressedBuffer, Header.dcmpSize);
 		}
 		else
 		{

--- a/Legion/src/Assets/wrap.cpp
+++ b/Legion/src/Assets/wrap.cpp
@@ -59,7 +59,7 @@ void RpakLib::ExportWrappedFile(const RpakLoadAsset& Asset, const string& Path)
 			char* decompressedBuffer = new char[Header.dcmpSize];
 			stream->Read((uint8_t*)decompressedBuffer, 0, Header.dcmpSize);
 			stream->Close();
-			ofs.write(decompressedBuffer, Header.dcmpSize);
+			ofs.write(decompressedBuffer, Header.dcmpSize - 1);
 		}
 		else
 		{


### PR DESCRIPTION
it works, but it feels wrong(?)

am i supposed to `delete` the buffers after im done with them? doing so causes a crash, but if i don't it doesn't seem to cause a memory leak by looking at the debug menu?

CPP is weird.